### PR TITLE
Fixes #16: Add Chapters to Chapter Index Page

### DIFF
--- a/project/chapters/models.py
+++ b/project/chapters/models.py
@@ -6,6 +6,7 @@ from wagtail.core.fields import RichTextField
 from wagtail.core.models import Page
 
 
+# Create your models here.
 class ChaptersIndexPage(Page):
     introduction = RichTextField()
 
@@ -22,7 +23,15 @@ class ChaptersIndexPage(Page):
 
     max_count = 1
 
-# Create your models here.
+    def get_context(self, request):
+        """
+        return a Queryset of Chapters
+        """
+        context = super().get_context(request)
+        context['chapters'] = Chapter.objects.child_of(self).live()
+        return context
+
+
 class Chapter(Page):
     class RegionChoices(models.TextChoices):
         AFRICA = "Africa", _("Africa")

--- a/project/chapters/templates/chapters/chapters_index_page.html
+++ b/project/chapters/templates/chapters/chapters_index_page.html
@@ -20,7 +20,7 @@
                 <p class="card-text mt-3" id="collapse_{{ chapters.grouper }}">
                     <div class="list-group">
                         {% for chapter in chapters.list %}
-                            <a class="list-group-item list-group-item-action" href="{% pageurl chapter %}">{{ chapter }}</a>
+                            <a class="list-group-item list-group-item-action list-group-item-primary" href="{% pageurl chapter %}">{{ chapter }}</a>
                         {% endfor %}
                     </div>
                 </p>

--- a/project/chapters/templates/chapters/chapters_index_page.html
+++ b/project/chapters/templates/chapters/chapters_index_page.html
@@ -10,15 +10,13 @@
 {{ page.introduction | richtext }}
 
 {% regroup chapters by region as chapters_by_region %}
-<ul>
-    {% for chapters in chapters_by_region %}
-        <li>{{ chapters.grouper }}</li>
-        <ul>
-            {% for chapter in chapters.list %}
-                <li>{{ chapter }}</li>
-            {% endfor %}
-        </ul>
-    {% endfor %}
-</ul>
+{% for chapters in chapters_by_region %}
+    <h3>{{ chapters.grouper }}</h3>
+    <ul>
+        {% for chapter in chapters.list %}
+            <li><a href="{% pageurl chapter %}">{{ chapter }}</a></li>
+        {% endfor %}
+    </ul>
+{% endfor %}
 
 {% endblock content %}

--- a/project/chapters/templates/chapters/chapters_index_page.html
+++ b/project/chapters/templates/chapters/chapters_index_page.html
@@ -8,4 +8,17 @@
 <h1>{{ page.title }}</h1>
 
 {{ page.introduction | richtext }}
+
+{% regroup chapters by region as chapters_by_region %}
+<ul>
+    {% for chapters in chapters_by_region %}
+        <li>{{ chapters.grouper }}</li>
+        <ul>
+            {% for chapter in chapters.list %}
+                <li>{{ chapter }}</li>
+            {% endfor %}
+        </ul>
+    {% endfor %}
+</ul>
+
 {% endblock content %}

--- a/project/chapters/templates/chapters/chapters_index_page.html
+++ b/project/chapters/templates/chapters/chapters_index_page.html
@@ -10,13 +10,24 @@
 {{ page.introduction | richtext }}
 
 {% regroup chapters by region as chapters_by_region %}
-{% for chapters in chapters_by_region %}
-    <h3>{{ chapters.grouper }}</h3>
-    <ul>
-        {% for chapter in chapters.list %}
-            <li><a href="{% pageurl chapter %}">{{ chapter }}</a></li>
-        {% endfor %}
-    </ul>
-{% endfor %}
+
+<div class="row mt-5">
+    {% for chapters in chapters_by_region %}
+    <div class="col">
+        <div class="card mb-5" style="width: 18rem;">
+            <div class="card-body">
+                <h5 class="card-title">{{ chapters.grouper }}</h5>
+                <p class="card-text mt-3" id="collapse_{{ chapters.grouper }}">
+                    <div class="list-group">
+                        {% for chapter in chapters.list %}
+                            <a class="list-group-item list-group-item-action" href="{% pageurl chapter %}">{{ chapter }}</a>
+                        {% endfor %}
+                    </div>
+                </p>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
 
 {% endblock content %}


### PR DESCRIPTION
Fixes #16

## Tasks
- [x] return a Queryset of Chapters by shadowing the get_context method of the ChapterIndexPage model
- [x]  use the chapters context variable to add a list of Chapters to the Chapter Index Page
- [x]  regroup the Chapters by region
- [x]  regions should be headings
- [x]  Chapters should link to the chapter page
- [x]  use Bootstrap classes to organize the page cleanly

## Demo
![image](https://user-images.githubusercontent.com/51958314/125196930-4c107800-e279-11eb-851e-ab37caea9509.png)